### PR TITLE
Align outbound content-type to the payload type

### DIFF
--- a/spring-cloud-starter-stream-processor-groovy-transform/src/main/java/org/springframework/cloud/stream/app/groovy/transform/processor/GroovyTransformProcessorConfiguration.java
+++ b/spring-cloud-starter-stream-processor-groovy-transform/src/main/java/org/springframework/cloud/stream/app/groovy/transform/processor/GroovyTransformProcessorConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2016 the original author or authors.
+ * Copyright 2015-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,7 +22,7 @@ import org.springframework.cloud.stream.annotation.EnableBinding;
 import org.springframework.cloud.stream.messaging.Processor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
-import org.springframework.integration.annotation.Transformer;
+import org.springframework.integration.annotation.ServiceActivator;
 import org.springframework.integration.groovy.GroovyScriptExecutingMessageProcessor;
 import org.springframework.integration.handler.MessageProcessor;
 import org.springframework.integration.scripting.ScriptVariableGenerator;
@@ -35,6 +35,7 @@ import org.springframework.scripting.support.ResourceScriptSource;
  * @author Mark Fisher
  * @author Marius Bogoevici
  * @author Gary Russell
+ * @author Christian Tzolov
  */
 @EnableBinding(Processor.class)
 @EnableConfigurationProperties(GroovyTransformProcessorProperties.class)
@@ -48,7 +49,7 @@ public class GroovyTransformProcessorConfiguration {
 	private GroovyTransformProcessorProperties properties;
 
 	@Bean
-	@Transformer(inputChannel = Processor.INPUT, outputChannel = Processor.OUTPUT)
+	@ServiceActivator(inputChannel = Processor.INPUT, outputChannel = Processor.OUTPUT)
 	public MessageProcessor<?> transformer() {
 		return new GroovyScriptExecutingMessageProcessor(
 				new ResourceScriptSource(properties.getScript()), scriptVariableGenerator);

--- a/spring-cloud-starter-stream-processor-groovy-transform/src/test/resources/script-convert-outbound-payload-type-to-string.groovy
+++ b/spring-cloud-starter-stream-processor-groovy-transform/src/test/resources/script-convert-outbound-payload-type-to-string.groovy
@@ -1,0 +1,1 @@
+new String(payload)


### PR DESCRIPTION
   If the outbound payload type is different from the inbound such then
   the outbound content-type header should be aligned with the new payload type.

   Discrepancy between the outbound payload type and the content-type metadata
   may cause selecting incorrect message converter and therefore fail to encode
   the outbound message into an appropriate wire format.

   Due to https://jira.spring.io/browse/INT-4397 the @Transfomer annotated processors
   blindly copy their input message headers into the output headers with no
   regards of the outbound payload type.

   The implementation of the @ServiceActivator doesn't suffer from this problem and can
   be used as drop-in workaround.

   Use the spring.cloud.stream.bindings.output.contentType property to set the outbound
   content type explicitly or otherwise it type will default to application/json

Resolves #1
Related To spring-cloud-stream-app-starters/app-starters-release#142